### PR TITLE
Update readme to point at nasa/harmony-gdal-adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# This repository has been archived. The Harmony GDAL Adapter is now maintained at at https://github.com/nasa/harmony-gdal-adapter
+:warning: The Harmony GDAL Adapter is now maintained at at https://github.com/nasa/harmony-gdal-adapter
 
 # harmony-gdal
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# This repository has been archived. The Harmony GDAL Adapter is now maintained at This project is now maintained at https://github.com/nasa/harmony-gdal-adapter
+# This repository has been archived. The Harmony GDAL Adapter is now maintained at at https://github.com/nasa/harmony-gdal-adapter
 
 # harmony-gdal
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repository has been archived. The Harmony GDAL Adapter is now maintained at This project is now maintained at https://github.com/nasa/harmony-gdal-adapter
+
 # harmony-gdal
 
 ![](https://data-services-github-badges.s3.amazonaws.com/cov.svg?dummy=true)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-:warning: The Harmony GDAL Adapter is now maintained at at https://github.com/nasa/harmony-gdal-adapter
+:warning: This project is now maintained as the Harmony GDAL Adapter at https://github.com/nasa/harmony-gdal-adapter
 
 # harmony-gdal
 


### PR DESCRIPTION
This adds a notice to the README to inform readers that the project is now maintained at nasa/harmony-gdal-adpater. I intent to [archive](https://docs.github.com/en/repositories/archiving-a-github-repository) this repository after this PR is merged.

@owenlittlejohns any feedback on language or formatting?